### PR TITLE
update cookie option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ using BingChat;
 var client = new BingChatClient(new BingChatClientOptions
 {
     // The "_U" cookie's value
-    Cookie = cookie
+    CookieU = strU,
 });
 
 var message = "Do you like cats?";
@@ -97,6 +97,46 @@ $ dotnet run --project src/BingChat.Cli/BingChat.Cli.csproj
 - [x] Implement a command line tool to interact with Bing Chat.
 - [ ] Provide a way to get the full result, like adaptive cards.
 - [ ] Add ability to set timeout.
+
+## Q&A
+
+UnauthorizedRequest Exception
+
+<details>
+    <summary>Solution</summary>
+    <p>There are multiple reasons. You may follow these steps to handle the problem.</p>
+    <p>1. Refresh the webpage, confirm that the '_U' value is up to date and copied correctly, and retry.</p>
+    <p>2. If you are using a proxy (VPN), try setting the global proxy, and retry. The code is as follows:</p>
+    <blockquote>
+    HttpClient.DefaultProxy = new WebProxy("127.0.0.1:8807"); //Your proxy address and port
+    </blockquote>
+    <p>3. Find another cookie named 'KievRPSSecAuth', set its value, and retry. The code is as follows:</p>
+    <blockquote>
+    var client = new BingChatClient(new BingChatClientOptions {
+    <br>
+    // The "_U" cookie's value
+    <br>
+    CookieU = strU,
+    <br>
+    // The "KievRPSSecAuth" cookie's value
+    <br>
+    CookieKievRPSSecAuth = strKievRPSSecAuth,
+    <br>
+    });
+    </blockquote>
+    <p>4. Open the browser menu > Extensions. Search for 'Cookie Editor' and install it.</p>
+    <p>Go to Bing Chat webpage and export all cookies to to a local file in JSON format.</p>
+    <p>Set file path value as follows (The "_U" and "KievRPSSecAuth" value are not needed at this time):</p>
+    <blockquote>
+    var client = new BingChatClient(new BingChatClientOptions {
+    <br>
+    // The exported cookie file path
+    <br>
+    CookieFilePath = strFilePath,
+    <br>
+    });
+    </blockquote>
+</details>
 
 ## Contributors
 

--- a/examples/BingChat.Examples/Simple.cs
+++ b/examples/BingChat.Examples/Simple.cs
@@ -10,7 +10,7 @@ public static partial class Examples
         // Construct the chat client
         var client = new BingChatClient(new BingChatClientOptions
         {
-            Cookie = cookie
+            CookieU = cookie
         });
 
         Console.WriteLine("Please wait...");

--- a/examples/BingChat.Examples/WithConversation.cs
+++ b/examples/BingChat.Examples/WithConversation.cs
@@ -10,7 +10,7 @@ public static partial class Examples
         // Construct the chat client
         var client = new BingChatClient(new BingChatClientOptions
         {
-            Cookie = cookie
+            CookieU = cookie
         });
 
         // Create a conversation, so we can continue chatting in the same context.

--- a/src/BingChat.Cli/Utils.cs
+++ b/src/BingChat.Cli/Utils.cs
@@ -9,7 +9,7 @@ internal static class Utils
         var cookie = Environment.GetEnvironmentVariable("BING_COOKIE");
         return new BingChatClient(new BingChatClientOptions
         {
-            Cookie = cookie
+            CookieU = cookie
         });
     }
 

--- a/src/BingChat/BingChatClientOptions.cs
+++ b/src/BingChat/BingChatClientOptions.cs
@@ -5,5 +5,15 @@ public sealed class BingChatClientOptions
     /// <summary>
     /// The _U cookie value
     /// </summary>
-    public string? Cookie { get; set; }
+    public string? CookieU { get; set; }
+
+    /// <summary>
+    /// The KievRPSSecAuth cookie value
+    /// </summary>
+    public string? CookieKievRPSSecAuth { get; set; }
+
+    /// <summary>
+    /// The exported cookie file path
+    /// </summary>
+    public string? CookieFilePath { get; set; }
 }


### PR DESCRIPTION
Fix #8 UnauthorizedRequest Exception

**Situation**
In my environment, only setting the "_U" cookie value will result in authentication failure, while setting the "_KievRPSSecAuth_" cookie value ,regardless of whether the "_U" cookie value is set or not, can successfully authenticate.
This issue can not be reproduced in the bsdayo's environment.

**Reason**
Setting the "_U" cookie value may not be a common solution for different environments and accounts.

**Modification**
While keeping the original option of the "_U" cookie value, two additional options are added.
1. Support for the "KievRPSSecAuth" cookie value.
2. Support for all cookie values from a JSON file, which is exported from the Cookie Editor.