### PR TITLE
error check and change tone

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ var client = new BingChatClient(new BingChatClientOptions
 {
     // The "_U" cookie's value
     CookieU = strU,
+    // Tone used for conversation
+    Tone = BingChatTone.Balanced,
 });
 
 var message = "Do you like cats?";

--- a/examples/BingChat.Examples/Simple.cs
+++ b/examples/BingChat.Examples/Simple.cs
@@ -10,7 +10,8 @@ public static partial class Examples
         // Construct the chat client
         var client = new BingChatClient(new BingChatClientOptions
         {
-            CookieU = cookie
+            CookieU = cookie,
+            Tone = BingChatTone.Balanced,
         });
 
         Console.WriteLine("Please wait...");

--- a/examples/BingChat.Examples/WithConversation.cs
+++ b/examples/BingChat.Examples/WithConversation.cs
@@ -10,7 +10,8 @@ public static partial class Examples
         // Construct the chat client
         var client = new BingChatClient(new BingChatClientOptions
         {
-            CookieU = cookie
+            CookieU = cookie,
+            Tone = BingChatTone.Balanced,
         });
 
         // Create a conversation, so we can continue chatting in the same context.

--- a/src/BingChat.Cli/Utils.cs
+++ b/src/BingChat.Cli/Utils.cs
@@ -9,7 +9,8 @@ internal static class Utils
         var cookie = Environment.GetEnvironmentVariable("BING_COOKIE");
         return new BingChatClient(new BingChatClientOptions
         {
-            CookieU = cookie
+            CookieU = cookie,
+            Tone = BingChatTone.Balanced,
         });
     }
 

--- a/src/BingChat/BingChatClient.cs
+++ b/src/BingChat/BingChatClient.cs
@@ -107,7 +107,7 @@ public sealed class BingChatClient : IBingChattable
         }
 
         return new BingChatConversation(
-            response.ClientId, response.ConversationId, response.ConversationSignature);
+            response.ClientId, response.ConversationId, response.ConversationSignature, _options.Tone);
     }
 
     /// <summary>

--- a/src/BingChat/BingChatClientOptions.cs
+++ b/src/BingChat/BingChatClientOptions.cs
@@ -1,5 +1,12 @@
 ﻿namespace BingChat;
 
+public enum BingChatTone : int
+{
+    Balanced = 0,
+    Creative = 1,
+    Precise = 2,
+}
+
 public sealed class BingChatClientOptions
 {
     /// <inheritdoc cref="CookieU"/>
@@ -20,4 +27,9 @@ public sealed class BingChatClientOptions
     /// The exported cookie file path
     /// </summary>
     public string? CookieFilePath { get; set; }
+
+    /// <summary>
+    /// Tone used for conversation (Default: Balanced)
+    /// </summary>
+    public BingChatTone Tone { get; set; }
 }

--- a/src/BingChat/BingChatConversation.cs
+++ b/src/BingChat/BingChatConversation.cs
@@ -37,6 +37,11 @@ internal sealed class BingChatConversation : IBingChattable
 
         string? GetAnswer(BingChatConversationResponse response)
         {
+            if (!response.Item.Result.Value.Equals("Success", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new BingChatException($"{response.Item.Result.Value}: {response.Item.Result.Message}");
+            }
+
             for (var index = response.Item.Messages.Length - 1; index >= 0; index--)
             {
                 var itemMessage = response.Item.Messages[index];

--- a/src/BingChat/BingChatConversation.cs
+++ b/src/BingChat/BingChatConversation.cs
@@ -14,9 +14,9 @@ internal sealed class BingChatConversation : IBingChattable
     private readonly BingChatRequest _request;
 
     internal BingChatConversation(
-        string clientId, string conversationId, string conversationSignature)
+        string clientId, string conversationId, string conversationSignature, BingChatTone tone)
     {
-        _request = new BingChatRequest(clientId, conversationId, conversationSignature);
+        _request = new BingChatRequest(clientId, conversationId, conversationSignature, tone);
     }
 
 

--- a/src/BingChat/BingChatConversationResponse.cs
+++ b/src/BingChat/BingChatConversationResponse.cs
@@ -21,6 +21,9 @@ internal sealed class Item
 {
     [JsonPropertyName("messages")]
     public Message[] Messages { get; set; }
+
+    [JsonPropertyName("result")]
+    public Result Result { get; set; }
 }
 
 internal sealed class Message
@@ -54,4 +57,13 @@ internal sealed class Body
 
     [JsonPropertyName("wrap")]
     public bool Wrap { get; set; }
+}
+
+internal sealed class Result
+{
+    [JsonPropertyName("value")]
+    public string Value { get; set; }
+
+    [JsonPropertyName("message")]
+    public string Message { get; set; }
 }


### PR DESCRIPTION
**Check for conversation response error**
Asking questions in an expired conversation will result in an exception, due to missing content in the response. This exception message is quite confusing, saying `Object reference not set to an instance of an object.`
The response text in an expired conversation is like:
```
{
    "type": 2,
    "invocationId": "8",
    "item": {
        "firstNewMessageIndex": null,
        "defaultChatName": null,
        "conversationId": "51D|BingProd|742...BD8",
        "requestId": "e899bba0-a575-4937-b273-5d67f9f0dd92",
        "telemetry": {
            "metrics": null,
            "startTime": "2023-05-15T08:33:38.7087779Z"
        },
        "result": {
            "value": "InvalidSession",
            "message": "Conversation '51D|BingProd|742...BD8' doesn't exist or has expired. Conversations expire after 06:00:00.",
            "serviceVersion": "20230513.5"
        }
    }
}
```
So I changed the exception message to the corresponding error messages in the conversation response.
After this modification, the exception message is like:
`InvalidSession: Conversation '51D|BingProd|742...BD8' doesn't exist or has expired. Conversations expire after 06:00:00.`


**Support for changing tone**
Solve #7
Add `Tone` property in `BingChatClientOptions`, which is an enum and supports all 3 tones. If not set, default tone is "Balanced".
Add corresponding arguments in the request payload.