### PR TITLE
feat: nativeaot support for nuget package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ obj/
 riderModule.iml
 /_ReSharper.Caches/
 .idea/
+.DS_Store
 build/
+publish/

--- a/src/BingChat/BingChatClient.cs
+++ b/src/BingChat/BingChatClient.cs
@@ -44,7 +44,7 @@ public sealed class BingChatClient : IBingChattable
             {
                 JsonNode? cookieJson = JsonNode.Parse(File.ReadAllText(_options.CookieFilePath));
                 cookies = new CookieContainer();
-                foreach (var cookieItemJson in (JsonArray)cookieJson)
+                foreach (var cookieItemJson in (JsonArray)cookieJson!)
                 {
                     if (cookieItemJson is null)
                         continue;
@@ -92,8 +92,9 @@ public sealed class BingChatClient : IBingChattable
         headers.Add("referer", "https://www.bing.com/search");
         headers.Add("referer-policy", "origin-when-cross-origin");
 
-        var response = await client.GetFromJsonAsync<BingCreateConversationResponse>(
-            "https://www.bing.com/turing/conversation/create");
+        var response = await client.GetFromJsonAsync(
+            "https://www.bing.com/turing/conversation/create",
+            SerializerContext.Default.BingCreateConversationResponse);
 
         if (response!.Result is { } errResult &&
             !errResult.Value.Equals("Success", StringComparison.OrdinalIgnoreCase))
@@ -129,7 +130,7 @@ internal sealed class BingCreateConversationResponse
         public string Message { get; set; } = null!;
     }
 
-    public CreateConversationResult? Result { get; set; } = null;
+    public CreateConversationResult? Result { get; set; }
 
     public string ConversationId { get; set; } = null!;
     public string ClientId { get; set; } = null!;

--- a/src/BingChat/BingChatConstants.cs
+++ b/src/BingChat/BingChatConstants.cs
@@ -1,0 +1,48 @@
+namespace BingChat;
+
+internal static class BingChatConstants
+{
+    internal static readonly string[] OptionSets = new[]
+    {
+        "nlu_direct_response_filter",
+        "deepleo",
+        "enable_debug_commands",
+        "disable_emoji_spoken_text",
+        "responsible_ai_policy_235",
+        "enablemm",
+        "cachewriteext",
+        "e2ecachewrite",
+        "nodlcpcwrite",
+        "nointernalsugg",
+        "saharasugg",
+        "rai267",
+        "sportsansgnd",
+        "enablenewsfc",
+        "dv3sugg",
+        "autosave",
+        "dlislog"
+    };
+
+    internal static readonly string[] CreativeOptionSets = OptionSets
+        .Concat(new[] { "h3imaginative", "clgalileo", "gencontentv3" })
+        .ToArray();
+
+    internal static readonly string[] PreciseOptionSets = OptionSets
+        .Concat(new[] { "h3precise", "clgalileo", "gencontentv3" })
+        .ToArray();
+
+    internal static readonly string[] BalancedOptionSets = OptionSets
+        .Concat(new[] { "galileo" })
+        .ToArray();
+
+    internal static readonly string[] AllowedMessageTypes = new[]
+    {
+        "Chat",
+        "InternalSearchQuery",
+        "InternalSearchResult",
+        "InternalLoaderMessage",
+        "RenderCardRequest",
+        "AdsQuery",
+        "SemanticSerp"
+    };
+}

--- a/src/BingChat/BingChatConversation.cs
+++ b/src/BingChat/BingChatConversation.cs
@@ -19,7 +19,6 @@ internal sealed class BingChatConversation : IBingChattable
         _request = new BingChatRequest(clientId, conversationId, conversationSignature, tone);
     }
 
-
     /// <inheritdoc/>
     public Task<string> AskAsync(string message)
     {
@@ -61,7 +60,7 @@ internal sealed class BingChatConversation : IBingChattable
             {
                 foreach (var part in text.Split(TerminalChar, StringSplitOptions.RemoveEmptyEntries))
                 {
-                    var json = JsonSerializer.Deserialize<BingChatConversationResponse>(part);
+                    var json = JsonSerializer.Deserialize(part, SerializerContext.Default.BingChatConversationResponse);
 
                     if (json is not { Type: 2 }) continue;
 

--- a/src/BingChat/BingChatConversationRequest.cs
+++ b/src/BingChat/BingChatConversationRequest.cs
@@ -1,0 +1,91 @@
+using System.Text.Json.Serialization;
+
+// ReSharper disable MemberCanBeInternal
+// ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+
+#pragma warning disable CS8618
+
+namespace BingChat;
+
+internal sealed class BingChatConversationRequest
+{
+    [JsonPropertyName("type")]
+    public int Type { get; set; }
+
+    [JsonPropertyName("invocationId")]
+    public string InvocationId { get; set; }
+
+    [JsonPropertyName("target")]
+    public string Target { get; set; }
+
+    [JsonPropertyName("arguments")]
+    public RequestArgument[] Arguments { get; set; }
+}
+
+internal sealed class RequestArgument
+{
+    [JsonPropertyName("source")]
+    public string Source { get; set; }
+
+    [JsonPropertyName("optionsSets")]
+    public string[] OptionsSets { get; set; }
+
+    [JsonPropertyName("allowedMessageTypes")]
+    public string[] AllowedMessageTypes { get; set; }
+
+    [JsonPropertyName("sliceIds")]
+    public string[] SliceIds { get; set; }
+
+    [JsonPropertyName("traceId")]
+    public string TraceId { get; set; }
+
+    [JsonPropertyName("isStartOfSession")]
+    public bool IsStartOfSession { get; set; }
+
+    [JsonPropertyName("message")]
+    public RequestMessage Message { get; set; }
+
+    [JsonPropertyName("tone")]
+    public string Tone { get; set; }
+
+    [JsonPropertyName("conversationSignature")]
+    public string ConversationSignature { get; set; }
+
+    [JsonPropertyName("participant")]
+    public Participant Participant { get; set; }
+
+    [JsonPropertyName("conversationId")]
+    public string ConversationId { get; set; }
+}
+
+internal sealed class RequestMessage
+{
+    // Are these needed?
+    // locale = ,
+    // market = ,
+    // region = ,
+    // location = ,
+    // locationHints: [],
+
+    [JsonPropertyName("timestamp")]
+    public DateTime Timestamp { get; set; }
+
+    [JsonPropertyName("author")]
+    public string Author { get; set; }
+
+    [JsonPropertyName("inputMethod")]
+    public string InputMethod { get; set; }
+
+    [JsonPropertyName("messageType")]
+    public string MessageType { get; set; }
+
+    [JsonPropertyName("text")]
+    public string Text { get; set; }
+}
+
+internal struct Participant
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+}

--- a/src/BingChat/BingChatConversationResponse.cs
+++ b/src/BingChat/BingChatConversationResponse.cs
@@ -14,19 +14,19 @@ internal sealed class BingChatConversationResponse
     public int Type { get; set; }
 
     [JsonPropertyName("item")]
-    public Item Item { get; set; }
+    public ResponseItem Item { get; set; }
 }
 
-internal sealed class Item
+internal sealed class ResponseItem
 {
     [JsonPropertyName("messages")]
-    public Message[] Messages { get; set; }
+    public ResponseMessage[] Messages { get; set; }
 
     [JsonPropertyName("result")]
-    public Result Result { get; set; }
+    public ResponseResult Result { get; set; }
 }
 
-internal sealed class Message
+internal sealed class ResponseMessage
 {
     [JsonPropertyName("text")]
     public string Text { get; set; }
@@ -44,10 +44,10 @@ internal sealed class Message
 internal sealed class AdaptiveCard
 {
     [JsonPropertyName("body")]
-    public Body[] Body { get; set; }
+    public ResponseBody[] Body { get; set; }
 }
 
-internal sealed class Body
+internal sealed class ResponseBody
 {
     [JsonPropertyName("type")]
     public string Type { get; set; }
@@ -59,7 +59,7 @@ internal sealed class Body
     public bool Wrap { get; set; }
 }
 
-internal sealed class Result
+internal sealed class ResponseResult
 {
     [JsonPropertyName("value")]
     public string Value { get; set; }

--- a/src/BingChat/BingChatSerializerContext.cs
+++ b/src/BingChat/BingChatSerializerContext.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace BingChat;
+
+[JsonSerializable(typeof(BingCreateConversationResponse))]
+[JsonSerializable(typeof(BingChatConversationRequest))]
+[JsonSerializable(typeof(BingChatConversationResponse))]
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+internal partial class SerializerContext : JsonSerializerContext { }


### PR DESCRIPTION
This PR changes reflection-based serialization to source-generated one. This has required fully defining previously anonymous type used for conversation requests.
The change allows the usage of the library in Native AOT scenarios (aka `<PublishAot>true</PublishAot>`).
Additionally, it includes minor fixes to warnings my IDE complained about :D
```
- switch to sourcegen serialization
- fix minor warnings
- move some array allocations to constants
- rename some types to resolve name conflicts (request vs response)
```

If you have any suggestions or comments regarding the style or perhaps better code structure of the change - do let me know!