### PR TITLE
feat: simple response text streaming + cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 > **Warning**
 > This library is **unofficial** and heavily depends on reverse-engineering. Use at your own risk.
 
-- [Quick Start](#quick-start)
-- [Interactive Command Line Tool](#interactive-command-line-tool)
-- [Roadmap](#roadmap)
-- [Q&A](#qa)
-- [Contributors](#contributors)
-- [License](#license)
+- [BingChat](#bingchat)
+  - [Quick Start](#quick-start)
+  - [Interactive Command Line Tool](#interactive-command-line-tool)
+  - [Roadmap](#roadmap)
+  - [Q\&A](#qa)
+  - [Contributors](#contributors)
+  - [License](#license)
 
 ## Quick Start
 
@@ -100,8 +101,11 @@ $ dotnet run --project src/BingChat.Cli/BingChat.Cli.csproj
 ## Roadmap
 
 - [x] Implement a command line tool to interact with Bing Chat.
-- [x] Provide a way to get the full result, like adaptive cards.
-- [ ] Add ability to set timeout.
+- [x] Provide a way to get the full result, like adaptive cards
+- [x] Add ability to set timeout
+- [ ] Validate that connectivity issues are gone after switching to SignalR
+- [ ] Research OptionSet specifics, analyze whether switching to `harmonyv3` enables the older model which has better performance
+- [ ] Expose rich response object via `.SendAsync(..)` to allow detailed access and control over the conversation state
 
 ## Q&A
 

--- a/examples/BingChat.Examples/Streaming.cs
+++ b/examples/BingChat.Examples/Streaming.cs
@@ -11,12 +11,12 @@ public static partial class Examples
         var client = new BingChatClient(new BingChatClientOptions
         {
             CookieU = cookie,
-            Tone = BingChatTone.Balanced,
+            Tone = BingChatTone.Creative,
         });
 
         Console.WriteLine("Please wait...\n");
 
-        var message = "List the most important quotes from today's news.";
+        var message = "Write an example creepypasta about BingChat.";
         var responseStream = client.StreamAsync(message);
 
         await foreach (var word in responseStream)

--- a/examples/BingChat.Examples/Streaming.cs
+++ b/examples/BingChat.Examples/Streaming.cs
@@ -1,0 +1,27 @@
+namespace BingChat.Examples;
+
+public static partial class Examples
+{
+    public static async Task AskAndStreamResponseText()
+    {
+        // Get the Bing "_U" cookie from wherever you like
+        var cookie = Environment.GetEnvironmentVariable("BING_COOKIE");
+
+        // Construct the chat client
+        var client = new BingChatClient(new BingChatClientOptions
+        {
+            CookieU = cookie,
+            Tone = BingChatTone.Balanced,
+        });
+
+        Console.WriteLine("Please wait...\n");
+
+        var message = "List the most important quotes from today's news.";
+        var responseStream = client.StreamAsync(message);
+
+        await foreach (var word in responseStream)
+        {
+            Console.Write(word);
+        }
+    }
+}

--- a/examples/BingChat.Examples/WithConversation.cs
+++ b/examples/BingChat.Examples/WithConversation.cs
@@ -6,7 +6,7 @@ public static partial class Examples
     {
         // Get the Bing "_U" cookie from wherever you like
         var cookie = Environment.GetEnvironmentVariable("BING_COOKIE");
-        
+
         // Construct the chat client
         var client = new BingChatClient(new BingChatClientOptions
         {
@@ -16,14 +16,14 @@ public static partial class Examples
 
         // Create a conversation, so we can continue chatting in the same context.
         var conversation = await client.CreateConversation();
-        
+
         Console.WriteLine("Please wait...");
         var firstMessage = "Do you like cats?";
         var answer = await conversation.AskAsync(firstMessage);
         Console.WriteLine($"First answer: {answer}");
 
         await Task.Delay(TimeSpan.FromSeconds(5));
-        
+
         Console.WriteLine("Please wait...");
         var secondMessage = "What did I just say?";
         answer = await conversation.AskAsync(secondMessage);

--- a/src/BingChat/BingChatConversation.cs
+++ b/src/BingChat/BingChatConversation.cs
@@ -95,7 +95,8 @@ public sealed class BingChatConversation : IBingChattable
             .AsTask()
             .ContinueWith(response =>
             {
-                // TODO: Properly format references and links, and append them at the end of the message.
+                // TODO: Properly format source attributions and adaptive cards, and append them at the end of the message.
+                // This is best done by extracting formatting logic from one-shot BuildAnswer used by AskAsync.
                 if (messageId != null)
                 {
                     var completedMessage = response.Result.Messages

--- a/src/BingChat/BingChatRequest.cs
+++ b/src/BingChat/BingChatRequest.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using System.Text.Json;
+﻿using BingChat.Model;
 
 namespace BingChat;
 
@@ -24,13 +23,13 @@ internal sealed class BingChatRequest
     /// Construct the initial payload for each message
     /// </summary>
     /// <param name="message">User message to Bing Chat</param>
-    internal BingChatConversationRequest ConstructInitialPayload(string message)
+    internal ChatRequest ConstructInitialPayload(string message)
     {
         var bytes = (stackalloc byte[16]);
         Random.Shared.NextBytes(bytes);
         var traceId = Convert.ToHexString(bytes).ToLowerInvariant();
 
-        var payload = new BingChatConversationRequest
+        var payload = new ChatRequest
         {
             Source = "cib",
             OptionsSets = _tone switch

--- a/src/BingChat/IBingChattable.cs
+++ b/src/BingChat/IBingChattable.cs
@@ -5,5 +5,13 @@ public interface IBingChattable
     /// <summary>
     /// Ask for an answer.
     /// </summary>
-    Task<string> AskAsync(string message);
+    Task<string> AskAsync(string message, CancellationToken ct = default);
+
+    /// <summary>
+    /// Ask for an answer.
+    /// </summary>
+    /// <returns>
+    /// Asynchronous stream consisting of response text words.
+    /// </returns>
+    IAsyncEnumerable<string> StreamAsync(string message, CancellationToken ct = default);
 }

--- a/src/BingChat/Model/ChatRequest.cs
+++ b/src/BingChat/Model/ChatRequest.cs
@@ -4,9 +4,9 @@
 
 #pragma warning disable CS8618
 
-namespace BingChat;
+namespace BingChat.Model;
 
-internal sealed class BingChatConversationRequest
+internal sealed class ChatRequest
 {
     public string Source { get; set; }
     public string[] OptionsSets { get; set; }

--- a/src/BingChat/Model/ChatResponse.cs
+++ b/src/BingChat/Model/ChatResponse.cs
@@ -4,18 +4,19 @@
 
 #pragma warning disable CS8618
 
-namespace BingChat;
+namespace BingChat.Model;
 
-internal sealed class BingChatConversationResponse
+internal sealed class ChatResponse
 {
     public ResponseMessage[] Messages { get; set; }
-    public ResponseResult Result { get; set; }
+    public ResponseResult? Result { get; set; }
 }
 
 internal sealed class ResponseMessage
 {
     public string? Text { get; set; }
     public string Author { get; set; }
+    public string MessageId { get; set; }
     public string? MessageType { get; set; }
     public AdaptiveCard[]? AdaptiveCards { get; set; }
     public SourceAttribution[]? SourceAttributions { get; set; }

--- a/src/BingChat/SerializerContext.cs
+++ b/src/BingChat/SerializerContext.cs
@@ -1,10 +1,11 @@
 using System.Text.Json.Serialization;
+using BingChat.Model;
 
 namespace BingChat;
 
 [JsonSerializable(typeof(BingCreateConversationResponse))]
-[JsonSerializable(typeof(BingChatConversationRequest))]
-[JsonSerializable(typeof(BingChatConversationResponse))]
+[JsonSerializable(typeof(ChatRequest))]
+[JsonSerializable(typeof(ChatResponse))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]


### PR DESCRIPTION
*mhmmm concurrent code, somehow this took one shot of espresso instead of 0.25 🤨*

Closes #14 

This PR introduces simple bare-bones response text streaming and lays down groundwork for future changes. I opted to approach it this way for now because designing stateful and rich response object will require much more work (updating the model to match JSON spec, properly exposing features like adaptive cards, references and other features in some reasonable way to the users, etc.).

I think it's better to address other issues first and only then go back to implementing the complex option. In the meantime, feel free to pick up the small TODO to match the behavior with `AskAsync`.

In addition, we now flow `CancellationToken` through all async calls which allows cancelling requests after a timeout with `using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));`

p.s.: you may want to squash-merge to skip commit spam xd

Try with
```cs
var bing = new BingChatClient(new BingChatClientOptions
{
    Tone = BingChatTone.Creative,
    CookieU = "[REDACTED]",
});

await bing
    .StreamAsync("Write me an example creepypasta about BingChat.")
    .ForEachAsync(word => Console.Write(word));

Console.WriteLine("\nDone!");
```