### PR TITLE
fix(cli): restore net7.0 target and fix ci

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -14,7 +14,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.x.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
 
       - name: Publish NuGet package
         uses: alirezanet/publish-nuget@v3.0.4

--- a/src/dotnet-bingchat/Commands/AskCommand.cs
+++ b/src/dotnet-bingchat/Commands/AskCommand.cs
@@ -10,7 +10,7 @@ public sealed class AskCommand : AsyncCommand<AskCommand.Settings>
     {
         [CommandArgument(0, "<message>")]
         [Description("The message to ask")]
-        public string[] Message { get; init; } = Array.Empty<string>();
+        public required string[] Message { get; init; }
     }
 
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)

--- a/src/dotnet-bingchat/dotnet-bingchat.csproj
+++ b/src/dotnet-bingchat/dotnet-bingchat.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>BingChat.Cli</RootNamespace>


### PR DESCRIPTION
Fixes https://github.com/bsdayo/BingChat/actions/runs/5147514252/jobs/9267997384
Let's see if this is enough to make `net7.0` target to work for CLI again