### PR TITLE
feat: retry transient connection errors

### DIFF
--- a/src/BingChat/BingChatConversation.cs
+++ b/src/BingChat/BingChatConversation.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Net.WebSockets;
+using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using BingChat.Model;
 using Microsoft.AspNetCore.Connections;
@@ -178,8 +179,19 @@ public sealed class BingChatConversation : IBingChattable
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance);
 
-        await conn.StartAsync(ct);
+        var attempts = 3;
+    retry:
+        try
+        {
+            await conn.StartAsync(ct);
+            return conn;
+        }
+        catch (WebSocketException)
+        {
+            if (--attempts > 0)
+                goto retry;
 
-        return conn;
+            throw;
+        }
     }
 }


### PR DESCRIPTION
Caught connection error:
```
System.Net.WebSockets.WebSocketException: The server returned status code '502' when status
code '101' was expected.
  at void System.Net.WebSockets.WebSocketHandle.ValidateResponse(HttpResponseMessage response,
     string secValue)
  at async Task System.Net.WebSockets.WebSocketHandle.ConnectAsync(Uri uri, HttpMessageInvoker
     invoker, CancellationToken cancellationToken, ClientWebSocketOptions options)
  at async Task System.Net.WebSockets.ClientWebSocket.ConnectAsyncCore(Uri uri,
     HttpMessageInvoker invoker, CancellationToken cancellationToken)
  at async ValueTask<WebSocket>
     Microsoft.AspNetCore.Http.Connections.Client.Internal.WebSocketsTransport.
     DefaultWebSocketFactory(WebSocketConnectionContext context, CancellationToken
     cancellationToken)
  at async Task Microsoft.AspNetCore.Http.Connections.Client.Internal.WebSocketsTransport.
     StartAsync(Uri url, TransferFormat transferFormat, CancellationToken cancellationToken)
  at async Task Microsoft.AspNetCore.Http.Connections.Client.HttpConnection.StartTransport(Uri
     connectUrl, HttpTransportType transportType, TransferFormat transferFormat,
     CancellationToken cancellationToken)
  at async Task Microsoft.AspNetCore.Http.Connections.Client.HttpConnection.
     SelectAndStartTransport(TransferFormat transferFormat, CancellationToken cancellationToken
     )
  at async Task Microsoft.AspNetCore.Http.Connections.Client.HttpConnection.StartAsyncCore(
     TransferFormat transferFormat, CancellationToken cancellationToken)
  at async Task Microsoft.AspNetCore.Http.Connections.Client.HttpConnection.StartAsync(
     TransferFormat transferFormat, CancellationToken cancellationToken)
  at async ValueTask<ConnectionContext>
     Microsoft.AspNetCore.Http.Connections.Client.HttpConnectionFactory.ConnectAsync(EndPoint
     endPoint, CancellationToken cancellationToken)
  at async ValueTask<ConnectionContext>
     Microsoft.AspNetCore.Http.Connections.Client.HttpConnectionFactory.ConnectAsync(EndPoint
     endPoint, CancellationToken cancellationToken)
  at async Task Microsoft.AspNetCore.SignalR.Client.HubConnection.StartAsyncCore(
     CancellationToken cancellationToken)
  at async Task Microsoft.AspNetCore.SignalR.Client.HubConnection.StartAsyncInner(
     CancellationToken cancellationToken)
  at async Task Microsoft.AspNetCore.SignalR.Client.HubConnection.StartAsync(CancellationToken
     cancellationToken)
  at async Task<HubConnection> BingChat.BingChatConversation.Connect(CancellationToken ct) in
     /home/runner/work/BingChat/BingChat/src/BingChat/BingChatConversation.cs:181
[TRUNCATED]
```
Possibly related to previously discussed interaction with Azure load balancer and SignalR.
For now, we can simply retry.